### PR TITLE
Account operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ This example mainly focuses in the contract defining how the business behaves as
 approach, but the same strategy can be applied to any other port. For examples, if there were multiple ways to
 store/query accounts, a single test could be defined to test all of them.
 
+## How to run
+
+The full stack can be run in a single jvm for demonstration purposes using `Main.kt` in the `web` project:
+```shell
+./gradlew :web:run
+```
+
 ## Technology
 
 The intention is to have as simple as possible code so very few external dependencies are used. It's implemented in

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -3,6 +3,8 @@ plugins {
 }
 
 dependencies {
+    api 'dev.forkhandles:result4k:1.6.0.0'
+
     testFixturesImplementation 'org.jetbrains.kotlin:kotlin-test-junit5'
     testFixturesImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.0'
     testFixturesImplementation 'com.natpryce:hamkrest:1.8.0.1'

--- a/domain/src/main/kotlin/lmirabal/bank/Bank.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/Bank.kt
@@ -8,4 +8,5 @@ interface Bank {
     fun createAccount(): BankAccount
     fun listAccounts(): List<BankAccount>
     fun deposit(id: BankAccountId, amount: Amount): BankAccount
+    fun withdraw(id: BankAccountId, amount: Amount): BankAccount
 }

--- a/domain/src/main/kotlin/lmirabal/bank/Bank.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/Bank.kt
@@ -1,8 +1,11 @@
 package lmirabal.bank
 
+import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
+import lmirabal.bank.model.BankAccountId
 
 interface Bank {
     fun createAccount(): BankAccount
     fun listAccounts(): List<BankAccount>
+    fun deposit(id: BankAccountId, amount: Amount): BankAccount
 }

--- a/domain/src/main/kotlin/lmirabal/bank/Bank.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/Bank.kt
@@ -1,12 +1,14 @@
 package lmirabal.bank
 
+import dev.forkhandles.result4k.Result
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 
 interface Bank {
     fun createAccount(): BankAccount
     fun listAccounts(): List<BankAccount>
     fun deposit(id: BankAccountId, amount: Amount): BankAccount
-    fun withdraw(id: BankAccountId, amount: Amount): BankAccount
+    fun withdraw(id: BankAccountId, amount: Amount): Result<BankAccount, NotEnoughFunds>
 }

--- a/domain/src/main/kotlin/lmirabal/bank/BankService.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/BankService.kt
@@ -15,4 +15,10 @@ class BankService(
     }
 
     override fun listAccounts(): List<BankAccount> = accountRepository.list()
+
+    override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
+        val account = accountRepository.list().first { it.id == id }
+        return account.deposit(amount)
+            .also { updatedAccount -> accountRepository.update(updatedAccount) }
+    }
 }

--- a/domain/src/main/kotlin/lmirabal/bank/BankService.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/BankService.kt
@@ -21,4 +21,10 @@ class BankService(
         return account.deposit(amount)
             .also { updatedAccount -> accountRepository.update(updatedAccount) }
     }
+
+    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
+        val account = accountRepository.list().first { it.id == id }
+        return account.withdraw(amount)
+            .also { updatedAccount -> accountRepository.update(updatedAccount) }
+    }
 }

--- a/domain/src/main/kotlin/lmirabal/bank/BankService.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/BankService.kt
@@ -1,9 +1,12 @@
 package lmirabal.bank
 
+import dev.forkhandles.result4k.Result
+import dev.forkhandles.result4k.peek
 import lmirabal.bank.data.BankAccountRepository
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 
 class BankService(
     private val accountRepository: BankAccountRepository,
@@ -22,9 +25,9 @@ class BankService(
             .also { updatedAccount -> accountRepository.update(updatedAccount) }
     }
 
-    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
+    override fun withdraw(id: BankAccountId, amount: Amount): Result<BankAccount, NotEnoughFunds> {
         val account = accountRepository.list().first { it.id == id }
         return account.withdraw(amount)
-            .also { updatedAccount -> accountRepository.update(updatedAccount) }
+            .peek { updatedAccount -> accountRepository.update(updatedAccount) }
     }
 }

--- a/domain/src/main/kotlin/lmirabal/bank/data/BankAccountRepository.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/data/BankAccountRepository.kt
@@ -4,5 +4,6 @@ import lmirabal.bank.model.BankAccount
 
 interface BankAccountRepository {
     fun add(account: BankAccount)
+    fun update(account: BankAccount)
     fun list(): List<BankAccount>
 }

--- a/domain/src/main/kotlin/lmirabal/bank/data/InMemoryBankAccountRepository.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/data/InMemoryBankAccountRepository.kt
@@ -1,13 +1,18 @@
 package lmirabal.bank.data
 
 import lmirabal.bank.model.BankAccount
+import lmirabal.bank.model.BankAccountId
 
 class InMemoryBankAccountRepository : BankAccountRepository {
-    private val accounts: MutableList<BankAccount> = arrayListOf()
+    private val accounts = mutableMapOf<BankAccountId, BankAccount>()
 
     override fun add(account: BankAccount) {
-        accounts.add(account)
+        accounts[account.id] = account
     }
 
-    override fun list(): List<BankAccount> = accounts
+    override fun update(account: BankAccount) {
+        add(account)
+    }
+
+    override fun list(): List<BankAccount> = accounts.values.toList()
 }

--- a/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
@@ -1,6 +1,6 @@
 package lmirabal.bank.model
 
-data class Amount(val minorUnits: Long) {
+data class Amount(val minorUnits: Long) : Comparable<Amount> {
     init {
         require(minorUnits >= 0)
     }
@@ -11,6 +11,10 @@ data class Amount(val minorUnits: Long) {
 
     operator fun minus(other: Amount): Amount {
         return Amount(minorUnits - other.minorUnits)
+    }
+
+    override fun compareTo(other: Amount): Int {
+        return minorUnits.compareTo(other.minorUnits)
     }
 
     companion object {

--- a/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
@@ -1,6 +1,13 @@
 package lmirabal.bank.model
 
 data class Amount(val minorUnits: Long) {
+    init {
+        require(minorUnits >= 0)
+    }
+
+    operator fun plus(other: Amount): Amount {
+        return Amount(minorUnits + other.minorUnits)
+    }
 
     companion object {
         val ZERO = Amount(0)

--- a/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/Amount.kt
@@ -9,6 +9,10 @@ data class Amount(val minorUnits: Long) {
         return Amount(minorUnits + other.minorUnits)
     }
 
+    operator fun minus(other: Amount): Amount {
+        return Amount(minorUnits - other.minorUnits)
+    }
+
     companion object {
         val ZERO = Amount(0)
     }

--- a/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
@@ -1,5 +1,8 @@
 package lmirabal.bank.model
 
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Result
+import dev.forkhandles.result4k.Success
 import java.util.UUID
 
 data class BankAccount(val id: BankAccountId, val balance: Amount) {
@@ -7,8 +10,9 @@ data class BankAccount(val id: BankAccountId, val balance: Amount) {
         return copy(balance = balance + amount)
     }
 
-    fun withdraw(amount: Amount): BankAccount {
-        return copy(balance = balance - amount)
+    fun withdraw(amount: Amount): Result<BankAccount, NotEnoughFunds> {
+        return if (amount <= balance) Success(copy(balance = balance - amount))
+        else Failure(NotEnoughFunds(id, balance, amount - balance))
     }
 }
 
@@ -18,3 +22,5 @@ data class BankAccountId(val value: UUID) {
         fun random() = BankAccountId(UUID.randomUUID())
     }
 }
+
+data class NotEnoughFunds(val id: BankAccountId, val balance: Amount, val additionalFundsRequired: Amount)

--- a/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
@@ -2,7 +2,11 @@ package lmirabal.bank.model
 
 import java.util.UUID
 
-data class BankAccount(val id: BankAccountId, val balance: Amount)
+data class BankAccount(val id: BankAccountId, val balance: Amount) {
+    fun deposit(amount: Amount): BankAccount {
+        return copy(balance = balance + amount)
+    }
+}
 
 data class BankAccountId(val value: UUID) {
 

--- a/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
+++ b/domain/src/main/kotlin/lmirabal/bank/model/BankAccount.kt
@@ -6,6 +6,10 @@ data class BankAccount(val id: BankAccountId, val balance: Amount) {
     fun deposit(amount: Amount): BankAccount {
         return copy(balance = balance + amount)
     }
+
+    fun withdraw(amount: Amount): BankAccount {
+        return copy(balance = balance - amount)
+    }
 }
 
 data class BankAccountId(val value: UUID) {

--- a/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
@@ -6,10 +6,8 @@ import lmirabal.bank.data.InMemoryBankAccountRepository
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
-import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
-@Tag("ImplementationReady")
 class BankServiceTest : BankTest() {
     private val idFactory = RecordingIdFactory()
     override val bank = BankService(InMemoryBankAccountRepository(), idFactory)

--- a/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
@@ -9,14 +9,26 @@ import lmirabal.bank.model.BankAccountId
 import org.junit.jupiter.api.Test
 
 class BankServiceTest : BankTest() {
-    private val id = BankAccountId.random()
-    private val idFactory = { id }
+    private val idFactory = RecordingIdFactory()
     override val bank = BankService(InMemoryBankAccountRepository(), idFactory)
 
     @Test
     fun createsAnAccount() {
         val account = bank.createAccount()
 
+        val id = idFactory.last()
         assertThat(account, equalTo(BankAccount(id, Amount.ZERO)))
+    }
+
+    class RecordingIdFactory : () -> BankAccountId {
+        private val values = mutableListOf<BankAccountId>()
+
+        override fun invoke(): BankAccountId {
+            return BankAccountId.random().also { values.add(it) }
+        }
+
+        fun last(): BankAccountId {
+            return values.last()
+        }
     }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/BankServiceTest.kt
@@ -6,8 +6,10 @@ import lmirabal.bank.data.InMemoryBankAccountRepository
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 
+@Tag("ImplementationReady")
 class BankServiceTest : BankTest() {
     private val idFactory = RecordingIdFactory()
     override val bank = BankService(InMemoryBankAccountRepository(), idFactory)

--- a/domain/src/test/kotlin/lmirabal/bank/data/InMemoryBankAccountRepositoryTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/data/InMemoryBankAccountRepositoryTest.kt
@@ -11,12 +11,25 @@ class InMemoryBankAccountRepositoryTest {
     private val repository = InMemoryBankAccountRepository()
 
     @Test
-    fun persistsAccounts() {
+    fun `persists accounts`() {
         val account1 = BankAccount(BankAccountId.random(), Amount(10))
         repository.add(account1)
         val account2 = BankAccount(BankAccountId.random(), Amount(20))
         repository.add(account2)
 
         assertThat(repository.list(), equalTo(listOf(account1, account2)))
+    }
+
+    @Test
+    fun `updates existing accounts`() {
+        val account1 = BankAccount(BankAccountId.random(), Amount(10))
+        repository.add(account1)
+        val account2 = BankAccount(BankAccountId.random(), Amount(20))
+        repository.add(account2)
+
+        val updatedAccount1 = BankAccount(account1.id, Amount(50))
+        repository.update(updatedAccount1)
+
+        assertThat(repository.list(), equalTo(listOf(updatedAccount1, account2)))
     }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
@@ -2,8 +2,13 @@ package lmirabal.bank.model
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.greaterThan
+import com.natpryce.hamkrest.greaterThanOrEqualTo
+import com.natpryce.hamkrest.lessThan
+import com.natpryce.hamkrest.lessThanOrEqualTo
 import com.natpryce.hamkrest.throws
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 
 class AmountTest {
     @Test
@@ -23,5 +28,15 @@ class AmountTest {
         val result = Amount(30) - Amount(10)
 
         assertThat(result, equalTo(Amount(20)))
+    }
+
+    @Test
+    fun `can be compared`() {
+        assertAll(
+            { assertThat(Amount(10), lessThan(Amount(20))) },
+            { assertThat(Amount(20), lessThanOrEqualTo(Amount(20))) },
+            { assertThat(Amount(20), greaterThan(Amount(10))) },
+            { assertThat(Amount(20), greaterThanOrEqualTo(Amount(20))) },
+        )
     }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
@@ -1,0 +1,20 @@
+package lmirabal.bank.model
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.throws
+import org.junit.jupiter.api.Test
+
+class AmountTest {
+    @Test
+    fun `value must be positive`() {
+        assertThat({ Amount(-10) }, throws<IllegalArgumentException>())
+    }
+
+    @Test
+    fun adds() {
+        val result = Amount(10) + Amount(30)
+
+        assertThat(result, equalTo(Amount(40)))
+    }
+}

--- a/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/AmountTest.kt
@@ -17,4 +17,11 @@ class AmountTest {
 
         assertThat(result, equalTo(Amount(40)))
     }
+
+    @Test
+    fun subtracts() {
+        val result = Amount(30) - Amount(10)
+
+        assertThat(result, equalTo(Amount(20)))
+    }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
@@ -14,4 +14,14 @@ class BankAccountTest {
 
         assertThat(updatedAccount, equalTo(BankAccount(id, Amount(300))))
     }
+
+    @Test
+    fun `decreases balance on withdrawal`() {
+        val id = BankAccountId.random()
+        val account = BankAccount(id, Amount(300))
+
+        val updatedAccount = account.withdraw(Amount(200))
+
+        assertThat(updatedAccount, equalTo(BankAccount(id, Amount(100))))
+    }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
@@ -2,6 +2,9 @@ package lmirabal.bank.model
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import dev.forkhandles.result4k.failureOrNull
+import dev.forkhandles.result4k.valueOrNull
 import org.junit.jupiter.api.Test
 
 class BankAccountTest {
@@ -20,8 +23,21 @@ class BankAccountTest {
         val id = BankAccountId.random()
         val account = BankAccount(id, Amount(300))
 
-        val updatedAccount = account.withdraw(Amount(200))
+        val result = account.withdraw(Amount(200))
 
-        assertThat(updatedAccount, equalTo(BankAccount(id, Amount(100))))
+        assertThat(result.valueOrNull(), present(equalTo(BankAccount(id, Amount(100)))))
+    }
+
+    @Test
+    fun `cannot withdraw more than balance`() {
+        val id = BankAccountId.random()
+        val account = BankAccount(id, Amount(300))
+
+        val result = account.withdraw(Amount(500))
+
+        assertThat(
+            result.failureOrNull(),
+            present(equalTo(NotEnoughFunds(id, Amount(300), Amount(200))))
+        )
     }
 }

--- a/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
+++ b/domain/src/test/kotlin/lmirabal/bank/model/BankAccountTest.kt
@@ -1,0 +1,17 @@
+package lmirabal.bank.model
+
+import com.natpryce.hamkrest.assertion.assertThat
+import com.natpryce.hamkrest.equalTo
+import org.junit.jupiter.api.Test
+
+class BankAccountTest {
+    @Test
+    fun `increases balance on deposit`() {
+        val id = BankAccountId.random()
+        val account = BankAccount(id, Amount(100))
+
+        val updatedAccount = account.deposit(Amount(200))
+
+        assertThat(updatedAccount, equalTo(BankAccount(id, Amount(300))))
+    }
+}

--- a/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
+++ b/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
@@ -2,18 +2,29 @@ package lmirabal.bank
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import lmirabal.bank.model.Amount
 import org.junit.jupiter.api.Test
 
 abstract class BankTest {
     abstract val bank: Bank
 
     @Test
-    fun listsAccounts() {
+    fun `lists accounts`() {
         val account1 = bank.createAccount()
         val account2 = bank.createAccount()
 
         val accounts = bank.listAccounts()
 
         assertThat(accounts, equalTo(listOf(account1, account2)))
+    }
+
+    @Test
+    fun `deposits into account`() {
+        val bankAccount = bank.createAccount()
+
+        bank.deposit(bankAccount.id, Amount(100))
+        val updatedAccount = bank.deposit(bankAccount.id, Amount(200))
+
+        assertThat(updatedAccount.balance, equalTo(Amount(300)))
     }
 }

--- a/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
+++ b/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
@@ -4,8 +4,6 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import lmirabal.bank.model.Amount
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.EnabledIf
-import org.junit.jupiter.api.extension.ExtensionContext
 
 abstract class BankTest {
     abstract val bank: Bank
@@ -30,7 +28,6 @@ abstract class BankTest {
         assertThat(updatedAccount.balance, equalTo(Amount(300)))
     }
 
-    @EnabledIf("implementationReady")
     @Test
     fun `withdraws from account`() {
         val bankAccount = bank.createAccount()
@@ -40,6 +37,4 @@ abstract class BankTest {
 
         assertThat(updatedAccount.balance, equalTo(Amount(100)))
     }
-
-    fun implementationReady(context: ExtensionContext) = "ImplementationReady" in context.tags
 }

--- a/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
+++ b/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
@@ -4,6 +4,8 @@ import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import lmirabal.bank.model.Amount
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIf
+import org.junit.jupiter.api.extension.ExtensionContext
 
 abstract class BankTest {
     abstract val bank: Bank
@@ -27,4 +29,17 @@ abstract class BankTest {
 
         assertThat(updatedAccount.balance, equalTo(Amount(300)))
     }
+
+    @EnabledIf("implementationReady")
+    @Test
+    fun `withdraws from account`() {
+        val bankAccount = bank.createAccount()
+
+        bank.deposit(bankAccount.id, Amount(300))
+        val updatedAccount = bank.withdraw(bankAccount.id, Amount(200))
+
+        assertThat(updatedAccount.balance, equalTo(Amount(100)))
+    }
+
+    fun implementationReady(context: ExtensionContext) = "ImplementationReady" in context.tags
 }

--- a/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
+++ b/domain/src/testFixtures/kotlin/lmirabal/bank/BankTest.kt
@@ -2,7 +2,11 @@ package lmirabal.bank
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
+import com.natpryce.hamkrest.present
+import dev.forkhandles.result4k.failureOrNull
+import dev.forkhandles.result4k.valueOrNull
 import lmirabal.bank.model.Amount
+import lmirabal.bank.model.NotEnoughFunds
 import org.junit.jupiter.api.Test
 
 abstract class BankTest {
@@ -35,6 +39,19 @@ abstract class BankTest {
         bank.deposit(bankAccount.id, Amount(300))
         val updatedAccount = bank.withdraw(bankAccount.id, Amount(200))
 
-        assertThat(updatedAccount.balance, equalTo(Amount(100)))
+        assertThat(updatedAccount.valueOrNull()?.balance, present(equalTo(Amount(100))))
+    }
+
+    @Test
+    fun `cannot withdraw from account more than balance`() {
+        val bankAccount = bank.createAccount()
+
+        bank.deposit(bankAccount.id, Amount(300))
+        val updatedAccount = bank.withdraw(bankAccount.id, Amount(500))
+
+        assertThat(
+            updatedAccount.failureOrNull(),
+            present(equalTo(NotEnoughFunds(bankAccount.id, Amount(300), Amount(200))))
+        )
     }
 }

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
@@ -23,6 +23,7 @@ fun bankHttp() = bankHttp(BankService(InMemoryBankAccountRepository()))
 
 internal const val BANK_ACCOUNTS_BASE_URL = "/bank/accounts"
 internal const val BANK_ACCOUNT_DEPOSIT_PATH = "/{id}/deposit"
+internal const val BANK_ACCOUNT_WITHDRAWAL_PATH = "/{id}/withdraw"
 internal val bankAccountLens = Body.auto<BankAccount>().toLens()
 internal val bankAccountListLens = Body.auto<List<BankAccount>>().toLens()
 internal val accountIdLens = Path.map({ BankAccountId(UUID.fromString(it)) }, { it.value.toString() }).of("id")
@@ -40,6 +41,12 @@ internal fun bankHttp(bank: Bank): HttpHandler {
                 val amount = amountLens(request)
 
                 Response(OK).with(bankAccountLens of bank.deposit(accountId, amount))
+            },
+            BANK_ACCOUNT_WITHDRAWAL_PATH bind POST to { request ->
+                val accountId = accountIdLens(request)
+                val amount = amountLens(request)
+
+                Response(OK).with(bankAccountLens of bank.withdraw(accountId, amount))
             }
         ),
     )

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
@@ -1,16 +1,20 @@
 package lmirabal.bank.http
 
+import dev.forkhandles.result4k.map
+import dev.forkhandles.result4k.recover
 import lmirabal.bank.Bank
 import lmirabal.bank.BankService
 import lmirabal.bank.data.InMemoryBankAccountRepository
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Response
+import org.http4k.core.Status.Companion.BAD_REQUEST
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Jackson.auto
@@ -28,6 +32,7 @@ internal val bankAccountLens = Body.auto<BankAccount>().toLens()
 internal val bankAccountListLens = Body.auto<List<BankAccount>>().toLens()
 internal val accountIdLens = Path.map({ BankAccountId(UUID.fromString(it)) }, { it.value.toString() }).of("id")
 internal val amountLens = Body.auto<Amount>().toLens()
+internal val notEnoughFundsLens = Body.auto<NotEnoughFunds>().toLens()
 
 internal fun bankHttp(bank: Bank): HttpHandler {
     return routes(
@@ -46,7 +51,9 @@ internal fun bankHttp(bank: Bank): HttpHandler {
                 val accountId = accountIdLens(request)
                 val amount = amountLens(request)
 
-                Response(OK).with(bankAccountLens of bank.withdraw(accountId, amount))
+                bank.withdraw(accountId, amount)
+                    .map { updatedAccount -> Response(OK).with(bankAccountLens of updatedAccount) }
+                    .recover { failure: NotEnoughFunds -> Response(BAD_REQUEST).with(notEnoughFundsLens of failure) }
             }
         ),
     )

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttp.kt
@@ -3,7 +3,9 @@ package lmirabal.bank.http
 import lmirabal.bank.Bank
 import lmirabal.bank.BankService
 import lmirabal.bank.data.InMemoryBankAccountRepository
+import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
+import lmirabal.bank.model.BankAccountId
 import org.http4k.core.Body
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
@@ -12,20 +14,33 @@ import org.http4k.core.Response
 import org.http4k.core.Status.Companion.OK
 import org.http4k.core.with
 import org.http4k.format.Jackson.auto
+import org.http4k.lens.Path
 import org.http4k.routing.bind
 import org.http4k.routing.routes
+import java.util.UUID
 
 fun bankHttp() = bankHttp(BankService(InMemoryBankAccountRepository()))
 
-internal const val BANK_ACCOUNTS_URL = "/bank/accounts"
+internal const val BANK_ACCOUNTS_BASE_URL = "/bank/accounts"
+internal const val BANK_ACCOUNT_DEPOSIT_PATH = "/{id}/deposit"
 internal val bankAccountLens = Body.auto<BankAccount>().toLens()
 internal val bankAccountListLens = Body.auto<List<BankAccount>>().toLens()
+internal val accountIdLens = Path.map({ BankAccountId(UUID.fromString(it)) }, { it.value.toString() }).of("id")
+internal val amountLens = Body.auto<Amount>().toLens()
 
 internal fun bankHttp(bank: Bank): HttpHandler {
     return routes(
-        BANK_ACCOUNTS_URL bind routes(
-            POST to { Response(OK).with(bankAccountLens of bank.createAccount()) },
-            GET to { Response(OK).with(bankAccountListLens of bank.listAccounts()) }
-        )
+        BANK_ACCOUNTS_BASE_URL bind routes(
+            routes(
+                POST to { Response(OK).with(bankAccountLens of bank.createAccount()) },
+                GET to { Response(OK).with(bankAccountListLens of bank.listAccounts()) }
+            ),
+            BANK_ACCOUNT_DEPOSIT_PATH bind POST to { request ->
+                val accountId = accountIdLens(request)
+                val amount = amountLens(request)
+
+                Response(OK).with(bankAccountLens of bank.deposit(accountId, amount))
+            }
+        ),
     )
 }

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
@@ -1,13 +1,19 @@
 package lmirabal.bank.http
 
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Result
+import dev.forkhandles.result4k.Success
 import lmirabal.bank.Bank
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
+import org.http4k.core.Response
+import org.http4k.core.Status
 import org.http4k.core.with
 
 class BankHttpClient(val http: HttpHandler) : Bank {
@@ -22,18 +28,23 @@ class BankHttpClient(val http: HttpHandler) : Bank {
     }
 
     override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
-        return changeBalanceAction(BANK_ACCOUNT_DEPOSIT_PATH, id, amount)
+        val response = changeBalanceAction(BANK_ACCOUNT_DEPOSIT_PATH, id, amount)
+        return bankAccountLens(response)
     }
 
-    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
-        return changeBalanceAction(BANK_ACCOUNT_WITHDRAWAL_PATH, id, amount)
+    override fun withdraw(id: BankAccountId, amount: Amount): Result<BankAccount, NotEnoughFunds> {
+        val response = changeBalanceAction(BANK_ACCOUNT_WITHDRAWAL_PATH, id, amount)
+        return when (response.status) {
+            Status.OK -> Success(bankAccountLens(response))
+            Status.BAD_REQUEST -> Failure(notEnoughFundsLens(response))
+            else -> throw Exception("Not expected: $response")
+        }
     }
 
-    private fun changeBalanceAction(actionPath: String, id: BankAccountId, amount: Amount): BankAccount {
-        val response = http(
+    private fun changeBalanceAction(actionPath: String, id: BankAccountId, amount: Amount): Response {
+        return http(
             Request(POST, BANK_ACCOUNTS_BASE_URL + actionPath)
                 .with(accountIdLens of id, amountLens of amount)
         )
-        return bankAccountLens(response)
     }
 }

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
@@ -22,14 +22,18 @@ class BankHttpClient(val http: HttpHandler) : Bank {
     }
 
     override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
-        val response = http(
-            Request(POST, BANK_ACCOUNTS_BASE_URL + BANK_ACCOUNT_DEPOSIT_PATH)
-                .with(accountIdLens of id, amountLens of amount)
-        )
-        return bankAccountLens(response)
+        return changeBalanceAction(BANK_ACCOUNT_DEPOSIT_PATH, id, amount)
     }
 
     override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
-        TODO("Not yet implemented")
+        return changeBalanceAction(BANK_ACCOUNT_WITHDRAWAL_PATH, id, amount)
+    }
+
+    private fun changeBalanceAction(actionPath: String, id: BankAccountId, amount: Amount): BankAccount {
+        val response = http(
+            Request(POST, BANK_ACCOUNTS_BASE_URL + actionPath)
+                .with(accountIdLens of id, amountLens of amount)
+        )
+        return bankAccountLens(response)
     }
 }

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
@@ -28,4 +28,8 @@ class BankHttpClient(val http: HttpHandler) : Bank {
         )
         return bankAccountLens(response)
     }
+
+    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
+        TODO("Not yet implemented")
+    }
 }

--- a/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
+++ b/http/src/main/kotlin/lmirabal/bank/http/BankHttpClient.kt
@@ -1,20 +1,31 @@
 package lmirabal.bank.http
 
 import lmirabal.bank.Bank
+import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
+import lmirabal.bank.model.BankAccountId
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
 import org.http4k.core.Request
+import org.http4k.core.with
 
 class BankHttpClient(val http: HttpHandler) : Bank {
     override fun createAccount(): BankAccount {
-        val response = http(Request(POST, BANK_ACCOUNTS_URL))
+        val response = http(Request(POST, BANK_ACCOUNTS_BASE_URL))
         return bankAccountLens(response)
     }
 
     override fun listAccounts(): List<BankAccount> {
-        val response = http(Request(GET, BANK_ACCOUNTS_URL))
+        val response = http(Request(GET, BANK_ACCOUNTS_BASE_URL))
         return bankAccountListLens(response)
+    }
+
+    override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
+        val response = http(
+            Request(POST, BANK_ACCOUNTS_BASE_URL + BANK_ACCOUNT_DEPOSIT_PATH)
+                .with(accountIdLens of id, amountLens of amount)
+        )
+        return bankAccountLens(response)
     }
 }

--- a/http/src/test/kotlin/lmirabal/bank/http/BankHttpIntegrationTest.kt
+++ b/http/src/test/kotlin/lmirabal/bank/http/BankHttpIntegrationTest.kt
@@ -9,7 +9,9 @@ import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
 
+@Tag("ImplementationReady")
 class BankHttpIntegrationTest : BankTest() {
     private val server = bankHttp().asServer(SunHttp())
     override val bank = BankHttpClient(

--- a/http/src/test/kotlin/lmirabal/bank/http/BankHttpIntegrationTest.kt
+++ b/http/src/test/kotlin/lmirabal/bank/http/BankHttpIntegrationTest.kt
@@ -9,9 +9,7 @@ import org.http4k.server.SunHttp
 import org.http4k.server.asServer
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Tag
 
-@Tag("ImplementationReady")
 class BankHttpIntegrationTest : BankTest() {
     private val server = bankHttp().asServer(SunHttp())
     override val bank = BankHttpClient(

--- a/http/src/test/kotlin/lmirabal/bank/http/BankHttpTest.kt
+++ b/http/src/test/kotlin/lmirabal/bank/http/BankHttpTest.kt
@@ -1,9 +1,7 @@
 package lmirabal.bank.http
 
 import lmirabal.bank.BankTest
-import org.junit.jupiter.api.Tag
 
-@Tag("ImplementationReady")
 class BankHttpTest : BankTest() {
     override val bank = BankHttpClient(bankHttp())
 }

--- a/http/src/test/kotlin/lmirabal/bank/http/BankHttpTest.kt
+++ b/http/src/test/kotlin/lmirabal/bank/http/BankHttpTest.kt
@@ -1,7 +1,9 @@
 package lmirabal.bank.http
 
 import lmirabal.bank.BankTest
+import org.junit.jupiter.api.Tag
 
+@Tag("ImplementationReady")
 class BankHttpTest : BankTest() {
     override val bank = BankHttpClient(bankHttp())
 }

--- a/web/build.gradle
+++ b/web/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'application'
+}
+
 dependencies {
     implementation project(':domain')
     implementation project(':http')
@@ -8,4 +12,8 @@ dependencies {
     testImplementation testFixtures(project(':domain'))
     testImplementation platform('org.http4k:http4k-bom:3.284.0')
     testImplementation 'org.http4k:http4k-testing-webdriver'
+}
+
+application {
+    mainClass = 'lmirabal.bank.web.MainKt'
 }

--- a/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
+++ b/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
@@ -1,15 +1,17 @@
 package lmirabal.bank.web
 
+import dev.forkhandles.result4k.map
+import dev.forkhandles.result4k.recover
 import lmirabal.bank.Bank
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.TEXT_HTML
 import org.http4k.core.HttpHandler
 import org.http4k.core.Method.GET
 import org.http4k.core.Method.POST
-import org.http4k.core.Request
 import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.SEE_OTHER
@@ -33,8 +35,8 @@ fun bankWeb(bank: Bank): HttpHandler {
             POST to CreateAccount(bank),
             GET to ListAccounts(bank)
         ),
-        "/{id}/deposit" bind POST to ChangeBalance(bank) { id, amount -> deposit(id, amount) },
-        "/{id}/withdraw" bind POST to ChangeBalance(bank) { id, amount -> withdraw(id, amount) },
+        "/{id}/deposit" bind POST to DepositAmount(bank),
+        "/{id}/withdraw" bind POST to WithdrawAmount(bank),
     )
 }
 
@@ -58,29 +60,46 @@ object ListAccounts {
 
 }
 
-class ChangeBalance(private val bank: Bank, private val action: Bank.(BankAccountId, Amount) -> BankAccount) :
-    HttpHandler {
+object DepositAmount {
     private val amountField = FormField.long().map { majorUnits -> majorUnits.toAmount() }.required("amount")
     private val formBody = Body.webForm(Validator.Feedback, amountField).toLens()
 
-    override fun invoke(request: Request): Response {
+    operator fun invoke(bank: Bank): HttpHandler = { request ->
         val id = request.path("id") ?: throw Exception("Bank account id must be present")
         val form = formBody(request)
         val amount = amountField(form)
-        action(bank, BankAccountId(UUID.fromString(id)), amount)
-        return Response(SEE_OTHER).header("location", "/")
+        bank.deposit(BankAccountId(UUID.fromString(id)), amount)
+        Response(SEE_OTHER).header("location", "/")
     }
-
-    private fun Long.toAmount() = Amount(
-        BigDecimal(this)
-            .movePointRight(2)
-            .longValueExact()
-    )
 }
 
-fun Amount.format(): String {
-    return BigDecimal(minorUnits).movePointLeft(2).longValueExact().toString()
+object WithdrawAmount {
+    private val amountField = FormField.long().map { majorUnits -> majorUnits.toAmount() }.required("amount")
+    private val formBody = Body.webForm(Validator.Feedback, amountField).toLens()
+
+    private val templates = HandlebarsTemplates().CachingClasspath()
+    private val viewLens = Body.viewModel(templates, TEXT_HTML).toLens()
+
+    operator fun invoke(bank: Bank): HttpHandler = { request ->
+        val id = request.path("id") ?: throw Exception("Bank account id must be present")
+        val form = formBody(request)
+        val amount = amountField(form)
+
+        bank.withdraw(BankAccountId(UUID.fromString(id)), amount)
+            .map { Response(SEE_OTHER).header("location", "/") }
+            .recover { failure: NotEnoughFunds -> Response(Status.OK).with(viewLens of failure.toView()) }
+    }
 }
+
+fun Amount.format(): String = BigDecimal(minorUnits).movePointLeft(2).longValueExact().toString()
+
+private fun Long.toAmount() = Amount(
+    BigDecimal(this).movePointRight(2).longValueExact()
+)
 
 data class BankAccountView(val id: String, val balance: String)
 data class BankAccountListView(val accounts: List<BankAccountView>) : ViewModel
+data class NotEnoughFundsView(val id: String, val balance: String, val additionalFundsRequired: String) : ViewModel
+
+fun NotEnoughFunds.toView() =
+    NotEnoughFundsView(id.value.toString(), balance.format(), additionalFundsRequired.format())

--- a/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
+++ b/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
@@ -3,6 +3,7 @@ package lmirabal.bank.web
 import lmirabal.bank.Bank
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
+import lmirabal.bank.model.BankAccountId
 import org.http4k.core.Body
 import org.http4k.core.ContentType.Companion.TEXT_HTML
 import org.http4k.core.HttpHandler
@@ -12,19 +13,26 @@ import org.http4k.core.Response
 import org.http4k.core.Status
 import org.http4k.core.Status.Companion.SEE_OTHER
 import org.http4k.core.with
+import org.http4k.lens.FormField
+import org.http4k.lens.Validator
+import org.http4k.lens.long
+import org.http4k.lens.webForm
 import org.http4k.routing.bind
+import org.http4k.routing.path
 import org.http4k.routing.routes
 import org.http4k.template.HandlebarsTemplates
 import org.http4k.template.ViewModel
 import org.http4k.template.viewModel
 import java.math.BigDecimal
+import java.util.UUID
 
 fun bankWeb(bank: Bank): HttpHandler {
     return routes(
         "/" bind routes(
             POST to CreateAccount(bank),
             GET to ListAccounts(bank)
-        )
+        ),
+        "/{id}/deposit" bind POST to DepositAmount(bank)
     )
 }
 
@@ -39,14 +47,36 @@ object ListAccounts {
     private val templates = HandlebarsTemplates().CachingClasspath()
     private val viewLens = Body.viewModel(templates, TEXT_HTML).toLens()
 
-    operator fun invoke(client: Bank): HttpHandler = {
-        val accounts = client.listAccounts().map { account -> account.toViewModel() }
+    operator fun invoke(bank: Bank): HttpHandler = {
+        val accounts = bank.listAccounts().map { account -> account.toViewModel() }
         Response(Status.OK).with(viewLens of BankAccountListView(accounts))
     }
 
     private fun BankAccount.toViewModel() = BankAccountView(id.value.toString(), balance.format())
 
-    private fun Amount.format() = BigDecimal(minorUnits).movePointLeft(2).longValueExact().toString()
+}
+
+object DepositAmount {
+    private val amountField = FormField.long().map { majorUnits -> majorUnits.toAmount() }.required("amount")
+    private val formBody = Body.webForm(Validator.Feedback, amountField).toLens()
+
+    operator fun invoke(bank: Bank): HttpHandler = { request ->
+        val id = request.path("id") ?: throw Exception("Bank account id must be present")
+        val form = formBody(request)
+        val amount = amountField(form)
+        bank.deposit(BankAccountId(UUID.fromString(id)), amount)
+        Response(SEE_OTHER).header("location", "/")
+    }
+
+    private fun Long.toAmount() = Amount(
+        BigDecimal(this)
+            .movePointRight(2)
+            .longValueExact()
+    )
+}
+
+fun Amount.format(): String {
+    return BigDecimal(minorUnits).movePointLeft(2).longValueExact().toString()
 }
 
 data class BankAccountView(val id: String, val balance: String)

--- a/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
+++ b/web/src/main/kotlin/lmirabal/bank/web/BankWeb.kt
@@ -46,7 +46,7 @@ object ListAccounts {
 
     private fun BankAccount.toViewModel() = BankAccountView(id.value.toString(), balance.format())
 
-    private fun Amount.format() = BigDecimal(minorUnits).movePointLeft(2).toPlainString()
+    private fun Amount.format() = BigDecimal(minorUnits).movePointLeft(2).longValueExact().toString()
 }
 
 data class BankAccountView(val id: String, val balance: String)

--- a/web/src/main/kotlin/lmirabal/bank/web/Main.kt
+++ b/web/src/main/kotlin/lmirabal/bank/web/Main.kt
@@ -1,0 +1,20 @@
+package lmirabal.bank.web
+
+import lmirabal.bank.http.BankHttpClient
+import lmirabal.bank.http.bankHttp
+import org.http4k.client.JavaHttpClient
+import org.http4k.core.Uri
+import org.http4k.core.then
+import org.http4k.filter.ClientFilters.SetBaseUriFrom
+import org.http4k.server.SunHttp
+import org.http4k.server.asServer
+
+fun main() {
+    val http = bankHttp().asServer(SunHttp(8080))
+    val httpClient = BankHttpClient(
+        SetBaseUriFrom(Uri.of("http://localhost:${http.port()}")).then(JavaHttpClient())
+    )
+    val app = bankWeb(httpClient).asServer(SunHttp(80))
+    http.start()
+    app.start()
+}

--- a/web/src/main/resources/lmirabal/bank/web/BankAccountListView.hbs
+++ b/web/src/main/resources/lmirabal/bank/web/BankAccountListView.hbs
@@ -37,9 +37,13 @@
                 <td>{{id}}</td>
                 <td>{{balance}}</td>
                 <td>
-                    <form method="POST" action="/{{id}}/deposit">
+                    <form id="deposit-form" method="POST" action="/{{id}}/deposit">
                         <input type="number" id="amount" name="amount"/>
                         <button id="deposit">Deposit</button>
+                    </form>
+                    <form id="withdraw-form" method="POST" action="/{{id}}/withdraw">
+                        <input type="number" id="amount" name="amount"/>
+                        <button id="withdraw">Withdraw</button>
                     </form>
                 </td>
             </tr>

--- a/web/src/main/resources/lmirabal/bank/web/BankAccountListView.hbs
+++ b/web/src/main/resources/lmirabal/bank/web/BankAccountListView.hbs
@@ -28,6 +28,7 @@
         <tr>
             <th>ID</th>
             <th>Balance</th>
+            <th>Actions</th>
         </tr>
         </thead>
         <tbody>
@@ -35,6 +36,12 @@
             <tr>
                 <td>{{id}}</td>
                 <td>{{balance}}</td>
+                <td>
+                    <form method="POST" action="/{{id}}/deposit">
+                        <input type="number" id="amount" name="amount"/>
+                        <button id="deposit">Deposit</button>
+                    </form>
+                </td>
             </tr>
         {{/accounts}}
         </tbody>

--- a/web/src/main/resources/lmirabal/bank/web/NotEnoughFundsView.hbs
+++ b/web/src/main/resources/lmirabal/bank/web/NotEnoughFundsView.hbs
@@ -1,0 +1,22 @@
+<html>
+<head>
+    <title>Bank</title>
+    <style>
+        h2 {
+            color: red;
+        }
+
+
+    </style>
+    <meta id="failure"/>
+    <meta id="balance" content="{{balance}}"/>
+    <meta id="additionalFundsRequired" content="{{additionalFundsRequired}}"/>
+</head>
+<body>
+<div>
+    <h2>Bank account with id {{id}} does not have enough funds</h2>
+    <p>Current balance: {{balance}}</p>
+    <p>Additional funds required: {{additionalFundsRequired}}</p>
+</div>
+</body>
+</html>

--- a/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
+++ b/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
@@ -1,5 +1,8 @@
 package lmirabal.bank.web
 
+import dev.forkhandles.result4k.Failure
+import dev.forkhandles.result4k.Result
+import dev.forkhandles.result4k.Success
 import lmirabal.bank.Bank
 import lmirabal.bank.BankTest
 import lmirabal.bank.http.BankHttpClient
@@ -7,6 +10,7 @@ import lmirabal.bank.http.bankHttp
 import lmirabal.bank.model.Amount
 import lmirabal.bank.model.BankAccount
 import lmirabal.bank.model.BankAccountId
+import lmirabal.bank.model.NotEnoughFunds
 import lmirabal.selenium.getElement
 import lmirabal.selenium.getTableColumn
 import lmirabal.selenium.getTableRows
@@ -46,34 +50,42 @@ class BankWebDriver(web: HttpHandler) : Bank {
     private fun WebElement.toBankAccount(): BankAccount {
         fun WebElement.getBalance(): Amount {
             val balanceTextInMajorUnits = getTableColumn(BALANCE_INDEX)
-            val balanceInMinorUnits = BigDecimal(balanceTextInMajorUnits).movePointRight(2).toLong()
-            return Amount(balanceInMinorUnits)
+            return balanceTextInMajorUnits.toAmount()
         }
 
         return BankAccount(getBankAccountId(), getBalance())
     }
 
     override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
-        return changeBalance("deposit", id, amount)
+        submitBalanceChange(type = "deposit", id, amount)
+        return driver.getBankAccounts().first { account -> account.id == id }
     }
 
-    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
-        return changeBalance("withdraw", id, amount)
+    override fun withdraw(id: BankAccountId, amount: Amount): Result<BankAccount, NotEnoughFunds> {
+        submitBalanceChange(type = "withdraw", id, amount)
+        return if (driver.findElement(By.id("failure")) == null) {
+            Success(driver.getBankAccounts().first { account -> account.id == id })
+        } else {
+            val balance = driver.getElement(By.id("balance")).getAttribute("content")
+            val additionalFundsRequired = driver.getElement(By.id("additionalFundsRequired")).getAttribute("content")
+            Failure(NotEnoughFunds(id, balance.toAmount(), additionalFundsRequired.toAmount()))
+        }
     }
 
-    private fun changeBalance(actionId: String, id: BankAccountId, amount: Amount): BankAccount {
+    private fun submitBalanceChange(type: String, id: BankAccountId, amount: Amount) {
         val row = driver.getTableRows().first { row -> row.getBankAccountId() == id }
 
-        val form = row.getElement(By.id("$actionId-form"))
+        val form = row.getElement(By.id("$type-form"))
         form.getElement(By.id("amount")).sendKeys(amount.format())
-        form.getElement(By.id(actionId)).submit()
-        return driver.getBankAccounts().first { account -> account.id == id }
+        form.getElement(By.id(type)).submit()
     }
 
     private fun WebElement.getBankAccountId(): BankAccountId {
         val idText = getTableColumn(ID_INDEX)
         return BankAccountId(UUID.fromString(idText))
     }
+
+    private fun String.toAmount() = Amount(BigDecimal(this).movePointRight(2).toLong())
 
     companion object {
         private const val ID_INDEX = 0

--- a/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
+++ b/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
@@ -61,6 +61,10 @@ class BankWebDriver(web: HttpHandler) : Bank {
         return driver.getBankAccounts().first { account -> account.id == id }
     }
 
+    override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
+        TODO("Not yet implemented")
+    }
+
     private fun WebElement.getBankAccountId(): BankAccountId {
         val idText = getTableColumn(ID_INDEX)
         return BankAccountId(UUID.fromString(idText))

--- a/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
+++ b/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
@@ -54,15 +54,20 @@ class BankWebDriver(web: HttpHandler) : Bank {
     }
 
     override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
-        val row = driver.getTableRows().first { row -> row.getBankAccountId() == id }
-
-        row.getElement(By.id("amount")).sendKeys(amount.format())
-        row.getElement(By.id("deposit")).submit()
-        return driver.getBankAccounts().first { account -> account.id == id }
+        return changeBalance("deposit", id, amount)
     }
 
     override fun withdraw(id: BankAccountId, amount: Amount): BankAccount {
-        TODO("Not yet implemented")
+        return changeBalance("withdraw", id, amount)
+    }
+
+    private fun changeBalance(actionId: String, id: BankAccountId, amount: Amount): BankAccount {
+        val row = driver.getTableRows().first { row -> row.getBankAccountId() == id }
+
+        val form = row.getElement(By.id("$actionId-form"))
+        form.getElement(By.id("amount")).sendKeys(amount.format())
+        form.getElement(By.id(actionId)).submit()
+        return driver.getBankAccounts().first { account -> account.id == id }
     }
 
     private fun WebElement.getBankAccountId(): BankAccountId {

--- a/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
+++ b/web/src/test/kotlin/lmirabal/bank/web/BankWebTest.kt
@@ -44,11 +44,6 @@ class BankWebDriver(web: HttpHandler) : Bank {
     }
 
     private fun WebElement.toBankAccount(): BankAccount {
-        fun WebElement.getBankAccountId(): BankAccountId {
-            val idText = getTableColumn(ID_INDEX)
-            return BankAccountId(UUID.fromString(idText))
-        }
-
         fun WebElement.getBalance(): Amount {
             val balanceTextInMajorUnits = getTableColumn(BALANCE_INDEX)
             val balanceInMinorUnits = BigDecimal(balanceTextInMajorUnits).movePointRight(2).toLong()
@@ -56,6 +51,19 @@ class BankWebDriver(web: HttpHandler) : Bank {
         }
 
         return BankAccount(getBankAccountId(), getBalance())
+    }
+
+    override fun deposit(id: BankAccountId, amount: Amount): BankAccount {
+        val row = driver.getTableRows().first { row -> row.getBankAccountId() == id }
+
+        row.getElement(By.id("amount")).sendKeys(amount.format())
+        row.getElement(By.id("deposit")).submit()
+        return driver.getBankAccounts().first { account -> account.id == id }
+    }
+
+    private fun WebElement.getBankAccountId(): BankAccountId {
+        val idText = getTableColumn(ID_INDEX)
+        return BankAccountId(UUID.fromString(idText))
     }
 
     companion object {


### PR DESCRIPTION
### Main to run the application

It provides a way to run the full system without intending to be for
production, as both services are kicked off in the same JVM using
in-memory storage.

This was missing from previous changes, as this was used to work out the
basic UI already in place.

### Limit web to handle only whole major units

Avoid extra complexity in input validation by not supporting fraction
values. This restriction is present only in the web layer, the HTTP
service and the domain still support any value.

### Implement end to end account deposits

Start writing a new functional test to prove how a deposit should alter
an account's balance which drives the design of the system by updating
the Bank interface and its collaborators to deliver the solution.

The BankAccount domain model starts taking shape and needing to affect
the account state means that we should write a test for it. It also
affects the Amount which also has tests of its own.

Once the domain is updated, the subsequent layers need to be updated
to add the mappings to bring deposits to life.

### Implement funds withdrawals in the domain

Make sure only the domain functional test is run using junit5 tags for
conditional execution.

### Implement HTTP mapping of funds withdrawals

### Add support to withdrawals in web UI

New form alongside deposits to allow withdrawals so that submitting the
form to the correct endpoint is easier. Also, generalise how they are
handled as they both received the same inputs and give back the same
output type.

Remove support for filtering tests that are not yet implemented.

### Validate accounts don't allow a negative balance

Use result type to express error case when withdrawing funds.

This is one example where driving the solution outside-in makes sense,
since the UI being the ultimate consumer should define what details the
domain needs to provide.
